### PR TITLE
할인 가격, 리뷰 정보 추가 크롤링 및 카테고리별 크롤링 결과 JSON

### DIFF
--- a/yogiyo_crawl.py
+++ b/yogiyo_crawl.py
@@ -96,7 +96,7 @@ def get_restaurant_infos(query, category):
         # 4. 최소주문금액
         infos['delivery_available_price'] = running_driver.find_element(By.XPATH, '//*[@id="content"]/div[2]/div[1]/div[1]/div[2]/ul/li[3]/span').text
 
-        # 5. 할인 정보 - 할인 정보 없으면 '추가할인 0%'라는 텍스트가 저장됨
+        # 5. 할인 정보
         infos['promotions'] = running_driver.find_element(By.XPATH, '//*[@id="content"]/div[2]/div[1]/div[1]/div[2]/ul/li[2]/span').text
         
         # 6. 로고 이미지


### PR DESCRIPTION
추가 항목

- 가격: 할인 전 가격과 후 가격 모두 받아왔습니다. - 할인 행사 미대상 메뉴는 할인 전후 가격이 같습니다.

- 할인 정보: '얼마 이상 구매 시 얼마 할인' 정보를 promotions 항목에 저장합니다.

- 리뷰: 리뷰어 아이디, 리뷰 날짜, 리뷰에 이미지 있을 시 이미지 가져옵니다.